### PR TITLE
Fix AppendEntriesRPC construction during log matching

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -237,8 +237,8 @@ main = do
           let nodeConfig = NodeConfig
                             { configNodeId = toS nid
                             , configNodeIds = allNodeIds
-                            , configElectionTimeout = (5000000, 15000000)
-                            , configHeartbeatTimeout = 1000000
+                            , configElectionTimeout = (1500000, 3000000)
+                            , configHeartbeatTimeout = 200000
                             }
           RaftExampleM $ lift acceptForkNode :: RaftExampleM Store StoreCmd ()
           electionTimerSeed <- liftIO randomIO

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -363,7 +363,7 @@ handleAction nodeConfig action = do
             (entries, prevLogIndex, prevLogTerm) <-
               case aedEntriesSpec aeData of
                 FromIndex idx -> do
-                  eLogEntries <- lift (readLogEntriesFrom idx)
+                  eLogEntries <- lift (readLogEntriesFrom (pred idx))
                   case eLogEntries of
                     Left err -> throw err
                     Right log ->


### PR DESCRIPTION
... and make timeouts in the example in `app/Main.hs` 10x greater than the ones listed in the paper as suggested timeouts.