### PR TITLE
Use decrIndex to avoid arithmetic underflow

### DIFF
--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -363,7 +363,7 @@ handleAction nodeConfig action = do
             (entries, prevLogIndex, prevLogTerm) <-
               case aedEntriesSpec aeData of
                 FromIndex idx -> do
-                  eLogEntries <- lift (readLogEntriesFrom (pred idx))
+                  eLogEntries <- lift (readLogEntriesFrom (decrIndex idx))
                   case eLogEntries of
                     Left err -> throw err
                     Right log ->

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -363,7 +363,7 @@ handleAction nodeConfig action = do
             (entries, prevLogIndex, prevLogTerm) <-
               case aedEntriesSpec aeData of
                 FromIndex idx -> do
-                  eLogEntries <- lift (readLogEntriesFrom (decrIndex idx))
+                  eLogEntries <- lift (readLogEntriesFrom (decrIndexWithDefault0 idx))
                   case eLogEntries of
                     Left err -> throw err
                     Right log ->

--- a/src/Raft/Leader.hs
+++ b/src/Raft/Leader.hs
@@ -46,7 +46,7 @@ handleAppendEntriesResponse ns@(NodeLeaderState ls) sender appendEntriesResp
   -- If AppendEntries fails (aerSuccess == False) because of log inconsistency,
   -- decrement nextIndex and retry
   | not (aerSuccess appendEntriesResp) = do
-      let newNextIndices = Map.adjust decrIndex sender (lsNextIndex ls)
+      let newNextIndices = Map.adjust decrIndexWithDefault0 sender (lsNextIndex ls)
           newLeaderState = ls { lsNextIndex = newNextIndices }
           Just newNextIndex = Map.lookup sender newNextIndices
       aeData <- mkAppendEntriesData newLeaderState (FromIndex newNextIndex)

--- a/src/Raft/Log.hs
+++ b/src/Raft/Log.hs
@@ -80,7 +80,7 @@ class Monad m => RaftReadLog m v where
         Right Nothing -> pure (Right Empty)
         Right (Just lastLogEntry)
           | entryIndex lastLogEntry < idx -> pure (Right Empty)
-          | otherwise -> fmap (|> lastLogEntry) <$> go (decrIndex (entryIndex lastLogEntry))
+          | otherwise -> fmap (|> lastLogEntry) <$> go (decrIndexWithDefault0 (entryIndex lastLogEntry))
     where
       go idx'
         | idx' < idx || idx' == 0 = pure (Right Empty)
@@ -89,7 +89,7 @@ class Monad m => RaftReadLog m v where
             case eLogEntry of
               Left err -> pure (Left err)
               Right Nothing -> panic "Malformed log"
-              Right (Just logEntry) -> fmap (|> logEntry) <$>  go (decrIndex idx')
+              Right (Just logEntry) -> fmap (|> logEntry) <$>  go (decrIndexWithDefault0 idx')
 
 type RaftLog m v = (RaftReadLog m v, RaftWriteLog m v, RaftDeleteLog m v)
 type RaftLogExceptions m = (Exception (RaftReadLogError m), Exception (RaftWriteLogError m), Exception (RaftDeleteLogError m))

--- a/src/Raft/Types.hs
+++ b/src/Raft/Types.hs
@@ -62,6 +62,8 @@ index0 = Index 0
 incrIndex :: Index -> Index
 incrIndex = succ
 
-decrIndex :: Index -> Index
-decrIndex (Index 0) = index0
-decrIndex i = pred i
+-- | Decrement index.
+-- If the given index is 0, return the given index
+decrIndexWithDefault0 :: Index -> Index
+decrIndexWithDefault0 (Index 0) = index0
+decrIndexWithDefault0 i = pred i

--- a/test/TestRaft.hs
+++ b/test/TestRaft.hs
@@ -248,7 +248,7 @@ testHandleAction sender action =
               (entries, prevLogIndex, prevLogTerm) <-
                 case aedEntriesSpec aeData of
                   FromIndex idx -> do
-                    eLogEntries <- runReaderT (readLogEntriesFrom (decrIndex idx)) nId
+                    eLogEntries <- runReaderT (readLogEntriesFrom (decrIndexWithDefault0 idx)) nId
                     case eLogEntries of
                       Left err -> throw err
                       Right log ->
@@ -260,7 +260,7 @@ testHandleAction sender action =
                   FromClientReq e ->
                     if entryIndex e /= Index 1
                       then do
-                        eLogEntry <- runReaderT (readLogEntry (decrIndex (entryIndex e))) nId
+                        eLogEntry <- runReaderT (readLogEntry (decrIndexWithDefault0 (entryIndex e))) nId
                         case eLogEntry of
                           Left err -> throw err
                           Right Nothing -> pure (Seq.singleton e, index0, term0)


### PR DESCRIPTION
The bug can be replicated (in master branch) using the example like:
- Run first node: `stack exec raft-example localhost:3001 localhost:3002`
- Run second node: `stack exec raft-example localhost:3002 localhost:3001`
- Run client `stack exec raft-example client`

- Then, the client does:
```
>>> addNode localhost:3001
>>> set testVar 3
>>> incr testVar
```

After the last client command, the leader crashed.
