### PR TITLE
Improvement: Set next index to index of last log received by Follower

### DIFF
--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -372,6 +372,13 @@ handleAction nodeConfig action = do
           -- Update the last log entry data
           modify $ \(RaftNodeState ns) ->
             RaftNodeState (setLastLogEntry ns entries)
+    -- TODO Maybe this should be called 'UpdateClientReqCacheTo`, since the
+    -- leader should only respond to the clien requests _up to_ the last commit
+    -- index, not _from_ the last commit index onwards... As soon as we start
+    -- testing with multiple clients, this will be incorrect. Instead, for each
+    -- entry between the previous commit index (before the leader updated it)
+    -- and the current commit index, the client issuer of that entry (if there
+    -- is one) should be responded to.
     UpdateClientReqCacheFrom idx -> do
       RaftNodeState ns <- get
       case ns of

--- a/src/Raft/RPC.hs
+++ b/src/Raft/RPC.hs
@@ -99,13 +99,18 @@ data AppendEntries v = AppendEntries
     -- ^ which read request the message corresponds to
   } deriving (Show, Generic, Serialize)
 
+data AERData
+  = AERReadReqNum Int
+  | AERLastReceivedEntryIndex Index
+  deriving (Show, Generic, Serialize)
+
 -- | Representation of the response from a follower to an AppendEntries message
 data AppendEntriesResponse = AppendEntriesResponse
   { aerTerm :: Term
     -- ^ current term for leader to update itself
   , aerSuccess :: Bool
     -- ^ true if follower contained entry matching aePrevLogIndex and aePrevLogTerm
-  , aerReadRequest :: Maybe Int
+  , aerData :: AERData
     -- ^ which read request the response corresponds to
   } deriving (Show, Generic, Serialize)
 


### PR DESCRIPTION
It has been observed that sometimes the next index for a particular follower was being incorrectly set in the case where a leader received a client write request immediately after broadcasting empty `AppendEntries` RPC for heartbeat messages. In this case, the last log entry of the leader would be one index greater than the last log entry possessed when broadcasting the empty `AppendEntries` RPC for the heartbeat. Upon receipt of an `AppendEntriesResponse` RPC, the leader was incorrectly setting the next index of the follower to one greater than the current last entry index, _which, at that point, was the index of the entry resulting from the client write request_.