### PR TITLE
Feature: Add ability to log with existing logger

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for raft
 
+## 0.4.1.0
+
+- Improvement: Users can now supply an existing logging function to log internal
+  raft node logs, useful for integration into existing applications.
+
 ## 0.4.0.0
 
 - API change: `MonadRaftAsync` is now `MonadRaftFork`, with a simpler API

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 - Improvement: Users can now supply an existing logging function to log internal
   raft node logs, useful for integration into existing applications.
+- Improvement: The example instances for `RaftClientSend` and
+  `RaftClientRecv` using unix sockets no longer need to fork a server to handle
+  responses from the raft node; the response is sent on the same socket the
+  client opens while sending the request.
 
 ## 0.4.0.0
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name:                libraft
 synopsis:            Raft consensus algorithm
 category:            Distributed Systems
-version:             0.4.0.0
+version:             0.4.1.0
 github:              "adjoint-io/raft"
 license:             BSD3
 author:              "Adjoint Inc."

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -148,7 +148,7 @@ runRaftNode
      , Exception (RaftPersistError m)
      )
    => RaftNodeConfig       -- ^ Node configuration
-   -> LogCtx               -- ^ Logs destination
+   -> LogCtx (RaftT v m)   -- ^ Logs destination
    -> Int                  -- ^ Timer seed
    -> sm                   -- ^ Initial state machine state
    -> m ()

--- a/src/Raft/Monad.hs
+++ b/src/Raft/Monad.hs
@@ -103,7 +103,7 @@ data RaftEnv v m = RaftEnv
   , resetElectionTimer :: m ()
   , resetHeartbeatTimer :: m ()
   , raftNodeConfig :: RaftNodeConfig
-  , raftNodeLogCtx :: LogCtx
+  , raftNodeLogCtx :: LogCtx (RaftT v m)
   }
 
 newtype RaftT v m a = RaftT


### PR DESCRIPTION
This PR allows the user to supply their own logging function for raft to use, if their application already has a logging built in. It adds the `LogDest` constructor:

```LogWith (forall m. MonadIO m => Severity -> Text -> m ())```

TODO:
- [x] Test locally
- [x] Minor version bump