### PR TITLE
Bug Fix: Correctly set AE RPC data resulting from Client Read Req

### DIFF
--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -441,9 +441,9 @@ handleAction action = do
           SendAppendEntriesRPC aeData -> do
             (entries, prevLogIndex, prevLogTerm, aeReadReq) <-
               case aedEntriesSpec aeData of
-                FromIndex idx -> mkPrevLogEntryDataByIdx idx
-                FromClientWriteReq e -> mkPrevEntryDataByEntry e
-                FromNewLeader e -> mkPrevEntryDataByEntry e
+                FromIndex idx -> attachNothing <$> mkPrevLogEntryDataByIdx idx
+                FromClientWriteReq e -> attachNothing <$> mkPrevEntryDataByEntry e
+                FromNewLeader e -> attachNothing <$> mkPrevEntryDataByEntry e
                 NoEntries spec -> do
                   let readReq =
                         case spec of
@@ -453,7 +453,7 @@ handleAction action = do
                     case getLastLogEntry ns of
                       NoLogEntries -> pure (index0, term0)
                       LastLogEntry e -> do
-                        (_,prevLogIdx, prevLogTerm) <- mkPrevEntryDataByEntry' e
+                        (_,prevLogIdx, prevLogTerm) <- mkPrevEntryDataByEntry e
                         pure (prevLogIdx, prevLogTerm)
                   pure (Empty, prevLogIdx, prevLogTerm, readReq)
             let leaderId = LeaderId (configNodeId nodeConfig)
@@ -471,14 +471,12 @@ handleAction action = do
           SendRequestVoteRPC rv -> pure (toRPC rv)
           SendRequestVoteResponseRPC rvr -> pure (toRPC rvr)
 
-    mkPrevLogEntryDataByIdx idx = do
-      (x,y,z) <- mkPrevLogEntryDataByIdx' idx
-      pure (x,y,z,Nothing)
+    attachNothing (x,y,z) = (x,y,z,Nothing)
 
     -- Make the previous log entry data given an index of an entry in the log.
     -- This function is used for creating heartbeat RPCs, where all logs from
     -- a particular index onwards are sent to a follower.
-    mkPrevLogEntryDataByIdx' idx = do
+    mkPrevLogEntryDataByIdx idx = do
       eLogEntries <- lift (readLogEntriesFrom (decrIndexWithDefault0 idx))
       case eLogEntries of
         Left err -> throwM err
@@ -489,16 +487,12 @@ handleAction action = do
               | otherwise -> pure (entries, entryIndex pe, entryTerm pe)
             _ -> pure (log, index0, term0)
 
-    mkPrevEntryDataByEntry e = do
-      (x,y,z) <- mkPrevEntryDataByEntry' e
-      pure (x,y,z,Nothing)
-
     -- Make the previous log entry data given a specific log entry and return
     -- the list of entries equal to the singleton including the original entry.
     -- This function is used for creating Append Entry RPCs resulting from
     -- client write requests, new leader no-op entries, empty heartbeat RPCs,
     -- and client read requests.
-    mkPrevEntryDataByEntry' e
+    mkPrevEntryDataByEntry e
       | entryIndex e == Index 1 = pure (singleton e, index0, term0)
       | otherwise = do
           let prevLogEntryIdx = decrIndexWithDefault0 (entryIndex e)

--- a/src/Raft/Follower.hs
+++ b/src/Raft/Follower.hs
@@ -88,8 +88,7 @@ handleAppendEntries ns@(NodeFollowerState fs) sender AppendEntries{..} = do
     updateCommitIndex :: FollowerState v -> FollowerState v
     updateCommitIndex followerState =
       case aeEntries of
-        Empty ->
-          followerState { fsCommitIndex = aeLeaderCommit }
+        Empty -> followerState
         _ :|> e ->
           let newCommitIndex = min aeLeaderCommit (entryIndex e)
           in followerState { fsCommitIndex = newCommitIndex }

--- a/src/Raft/RPC.hs
+++ b/src/Raft/RPC.hs
@@ -61,8 +61,7 @@ rpcTerm = \case
   RequestVoteResponseRPC rvr -> rvrTerm rvr
 
 data NoEntriesSpec
-  = FromInconsistency
-  | FromHeartbeat
+  = FromHeartbeat
   | FromClientReadReq Int
   deriving (Show)
 


### PR DESCRIPTION
While using this library from within a bespoke application, it was noticed that in periods where ~10 client read and/or write requests are being handled, the system sometimes diverges when a follower is handling an append entry RPC from the leader resulting from a client read request when the client has yet to receive the immediately previous append entry RPC resulting from a client write. The follower responded with an AER RPC with `success = False` because the leader's previous log index had incremented before the the follower had received the client write request AE RPC broadcast from the leader. **The leader was incorrectly setting the AE RPC `aePrevLogEntryIndex` and `aePrevLogEntryTerm` RPC fields when constructing an RPC as a result of a client read.** This caused incorrect behavior where the leader continually decremented the follower's "next Index" field and attempting to reconcile the log, ultimately preventing the follower from ever receiving new, valid log entries and as the system repeatedly tried to reconcile the log inconsistency without ever making progress. The follower had all of the logs the leader had except one all along! 

I wish I could better specify the origin of this bug, but the complex logs that I had to spend a long time parsing yielded only the above description of the problem. It was immediately obvious, however, when looking at the `NoEntries` case of `mkRPCfromSendRPCAction`, which used the `lastLogEntry` term and index instead of the "previous log entry" term and index. This PR fixes this issue such that the leader now uses the correct term and index as the `aePrevLogIndex/Term` fields when constructing the AE RPC to broadcast to followers.