### PR TITLE
Feature: Raft node metrics

### DIFF
--- a/app/Client.hs
+++ b/app/Client.hs
@@ -128,7 +128,7 @@ clientRepl :: [ByteString] -> IO ()
 clientRepl nodes = do
   let clientHost = "localhost"
   clientPort <- RS.getFreePort
-  let clientId = ClientId $ RS.hostPortToNid (clientHost, clientPort)
+  let clientId = ClientId $ RS.hostPortToNid (clientHost, show clientPort)
   clientRespChan <- RS.newClientRespChan
   RS.runRaftSocketClientM clientId mempty clientRespChan $ do
     evalRepl (pure ">>> ")

--- a/app/Node.hs
+++ b/app/Node.hs
@@ -22,7 +22,6 @@ import Control.Monad.Catch
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 
-import System.Random
 import System.FilePath ((</>))
 import qualified System.Directory as Directory
 
@@ -34,8 +33,6 @@ import Raft.Config
 import Raft.Log
 import Raft.Log.PostgreSQL
 
-
-import qualified Examples.Raft.Socket.Node as RS
 import Examples.Raft.Socket.Node
 import qualified Examples.Raft.Socket.Common as RS
 import Examples.Raft.FileStore.Log
@@ -92,16 +89,15 @@ nodeMain storageState storageType nid nids = do
           runRaftPersistFileStoreT nPersistFile $ do
             let allNodeIds = Set.fromList (nid : nids)
             let nodeConfig = RaftNodeConfig
-                              { configNodeId = toS nid
-                              , configNodeIds = allNodeIds
+                              { raftConfigNodeId = toS nid
+                              , raftConfigNodeIds = allNodeIds
                               -- These are recommended timeouts from the original
                               -- raft paper and the ARC report.
-                              , configElectionTimeout = (150000, 300000)
-                              , configHeartbeatTimeout = 50000
-                              , configStorageState = storageState
+                              , raftConfigElectionTimeout = (150000, 300000)
+                              , raftConfigHeartbeatTimeout = 50000
+                              , raftConfigStorageState = storageState
                               }
-            electionTimerSeed <- liftIO randomIO
-            runRaftNode nodeConfig (LogCtx LogStdout Debug) electionTimerSeed (mempty :: Store)
+            runRaftNode nodeConfig defaultOptionalRaftNodeConfig (LogCtx LogStdout Debug) (mempty :: Store)
 
 cleanStorage :: FilePath -> LogStorage -> IO ()
 cleanStorage nodeDir ls = do
@@ -139,4 +135,3 @@ mkExampleDir nid = do
   tmpDir <- Directory.getTemporaryDirectory
   let nodeDir = tmpDir </> toS nid
   pure nodeDir
-

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
 - dejafu >= 1.12.0.0
 - stm
 - async
+- monad-metrics
 
 default-extensions:
   NoImplicitPrelude

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
 - stm
 - async
 - monad-metrics
+- ekg
 
 default-extensions:
   NoImplicitPrelude

--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,6 @@ dependencies:
 - monad-metrics
 - ekg
 - ekg-core
-- microlens
 
 default-extensions:
   NoImplicitPrelude

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ dependencies:
 - async
 - monad-metrics
 - ekg
+- ekg-core
 
 default-extensions:
   NoImplicitPrelude
@@ -69,10 +70,7 @@ executables:
   raft-example:
     main:                Main.hs
     source-dirs:         app
-    ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts "-with-rtsopts=-N -T"
     dependencies:
     - libraft
     - stm

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - protolude
 - mtl
 - containers
+- unordered-containers
 - text
 - concurrency >= 1.3.0.0
 - transformers
@@ -54,6 +55,7 @@ dependencies:
 - monad-metrics
 - ekg
 - ekg-core
+- microlens
 
 default-extensions:
   NoImplicitPrelude

--- a/src/Examples/Raft/Socket/Node.hs
+++ b/src/Examples/Raft/Socket/Node.hs
@@ -72,7 +72,7 @@ deriving instance MonadMask m => MonadMask (RaftSocketT sm v m)
 -- Raft Instances --
 --------------------
 
-instance (MonadMask m, MonadCatch m, MonadIO m, S.Serialize sm, S.Serialize v) => RaftSendClient (RaftSocketT sm v m) sm v where
+instance (RaftStateMachinePure sm v, MonadMask m, MonadCatch m, MonadIO m, S.Serialize sm, S.Serialize v) => RaftSendClient (RaftSocketT sm v m) sm v where
   sendClient clientId msg = do
     NodeSocketEnv{..} <- ask
     mRespVar <- liftIO . atomically . fmap (Map.lookup clientId) . readTVar $ nsClientReqResps

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -180,7 +180,7 @@ runRaftNode nodeConfig@RaftNodeConfig{..} optConfig logCtx initStateMachine = do
 
     -- Fork the monitoring server for metrics
     logInfo ("Forking metrics server on port " <> show metricsPort <> "...")
-    liftIO (forkServer "localhost" 9000)
+    liftIO (forkServer "localhost" (fromIntegral metricsPort))
 
     -- These event producers need access to logging, thus they live in RaftT
     --

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -293,7 +293,8 @@ handleEventLoop initStateMachine = do
 
           -- Perform core state machine transition, handling the current event
           nodeConfig <- asks raftNodeConfig
-          let transitionEnv = TransitionEnv nodeConfig stateMachine raftNodeState
+          raftNodeMetrics <- getRaftNodeMetrics
+          let transitionEnv = TransitionEnv nodeConfig stateMachine raftNodeState raftNodeMetrics
           pure (Raft.Handle.handleEvent raftNodeState transitionEnv persistentState event)
 
       case mRes of

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -179,9 +179,12 @@ runRaftNode nodeConfig@RaftNodeConfig{..} optConfig logCtx initStateMachine = do
   runRaftT initRaftNodeState raftEnv $ do
 
     -- Fork the monitoring server for metrics
-    logInfo ("Forking metrics server on port " <> show metricsPort <> "...")
-    store <- Metrics._metricsStore <$> Metrics.getMetrics
-    liftIO (EKG.forkServerWith store "localhost" (fromIntegral metricsPort))
+    case metricsPort of
+      Nothing -> pure ()
+      Just port -> do
+        logInfo ("Forking metrics server on port " <> show port <> "...")
+        store <- Metrics._metricsStore <$> Metrics.getMetrics
+        void $ liftIO (EKG.forkServerWith store "localhost" (fromIntegral port ))
 
     logInfo ("Initialized election timer with seed " <> show timerSeed <> "...")
 

--- a/src/Raft/Candidate.hs
+++ b/src/Raft/Candidate.hs
@@ -67,7 +67,7 @@ handleRequestVoteResponse (NodeCandidateState candidateState@CandidateState{..})
       | not rvrVoteGranted -> pure $ candidateResultState Noop candidateState
       | otherwise -> do
           let newCsVotes = Set.insert sender csVotes
-          cNodeIds <- asks (configNodeIds . nodeConfig)
+          cNodeIds <- asks (raftConfigNodeIds . nodeConfig)
           if not $ hasMajority cNodeIds newCsVotes
             then do
               let newCandidateState = candidateState { csVotes = newCsVotes }
@@ -83,7 +83,7 @@ handleRequestVoteResponse (NodeCandidateState candidateState@CandidateState{..})
     mkNoopEntry = do
       let lastLogEntryIdx = lastLogEntryIndex csLastLogEntry
       currTerm <- gets currentTerm
-      nid <- asks (configNodeId . nodeConfig)
+      nid <- asks (raftConfigNodeId . nodeConfig)
       pure Entry
         { entryIndex = succ lastLogEntryIdx
         , entryTerm  = currTerm

--- a/src/Raft/Client.hs
+++ b/src/Raft/Client.hs
@@ -103,10 +103,7 @@ import Raft.Types
 {- This is the interface with which Raft nodes interact with client programs -}
 
 -- | Interface for Raft nodes to send messages to clients
---
--- TODO It would be really nice if 'RSMP' was a superclass, but currently this
--- can't happen because of cyclic imports.
-class RaftSendClient m sm v where
+class RaftStateMachinePure sm v => RaftSendClient m sm v where
   sendClient :: ClientId -> ClientResponse sm v -> m ()
 
 -- | Interface for Raft nodes to receive messages from clients

--- a/src/Raft/Client.hs
+++ b/src/Raft/Client.hs
@@ -26,8 +26,11 @@ module Raft.Client
 -- ** Client Requests
 , ClientRequest(..)
 , ClientReq(..)
+, ClientReqType(..)
 , ClientReadReq(..)
 , ReadEntriesSpec(..)
+, ClientWriteReq(..)
+, ClientMetricsReq(..)
 
 -- ** Client Responses
 , ClientResponse(..)
@@ -94,6 +97,7 @@ import System.Timeout.Lifted (timeout)
 
 import Raft.Log (Entry, Entries, ReadEntriesSpec)
 import Raft.StateMachine
+import Raft.Metrics (RaftNodeMetrics)
 import Raft.Types
 
 --------------------------------------------------------------------------------
@@ -125,7 +129,8 @@ instance S.Serialize v => S.Serialize (ClientRequest v)
 -- | Representation of a client request
 data ClientReq v
   = ClientReadReq ClientReadReq -- ^ Request the latest state of the state machine
-  | ClientWriteReq SerialNum v -- ^ Write a command
+  | ClientWriteReq (ClientWriteReq v) -- ^ Write a command
+  | ClientMetricsReq ClientMetricsReq -- ^ Request the metrics of a raft node
   deriving (Show, Generic)
 
 instance S.Serialize v => S.Serialize (ClientReq v)
@@ -134,6 +139,22 @@ data ClientReadReq
   = ClientReadEntries ReadEntriesSpec
   | ClientReadStateMachine
   deriving (Show, Generic, S.Serialize)
+
+data ClientWriteReq v
+  = ClientCmdReq SerialNum v -- ^ Issue a command to update the state machine
+  deriving (Show, Generic, S.Serialize)
+
+data ClientMetricsReq
+  = ClientAllMetricsReq
+  deriving (Show, Generic, S.Serialize)
+
+-- | Typeclass to make it easier to write polymorphic functions over ClientReq
+-- types
+class ClientReqType a v
+
+instance ClientReqType ClientReadReq v
+instance ClientReqType (ClientWriteReq v) v
+instance ClientReqType ClientMetricsReq v
 
 --------------------------------------------------------------------------------
 -- Client Responses
@@ -144,6 +165,7 @@ data ClientRespSpec sm v
   = ClientReadRespSpec (ClientReadRespSpec sm)
   | ClientWriteRespSpec (ClientWriteRespSpec sm v)
   | ClientRedirRespSpec CurrentLeader
+  | ClientMetricsRespSpec RaftNodeMetrics
   deriving (Generic)
 
 deriving instance (Show sm, Show v, Show (RaftStateMachinePureError sm v)) => Show (ClientRespSpec sm v)
@@ -172,6 +194,8 @@ data ClientResponse sm v
     -- ^ Respond with the index of the entry appended to the log
   | ClientRedirectResponse ClientRedirResp
     -- ^ Respond with the node id of the current leader
+  | ClientMetricsResponse ClientMetricsResp
+    -- ^ Respond with the node's current metrics
   deriving (Generic)
 
 deriving instance (Show sm, Show v, Show (ClientWriteResp sm v)) => Show (ClientResponse sm v)
@@ -197,6 +221,10 @@ deriving instance (S.Serialize sm, S.Serialize v, S.Serialize (RaftStateMachineP
 -- | Representation of a redirect response to a client
 data ClientRedirResp
   = ClientRedirResp CurrentLeader
+  deriving (Show, Generic, S.Serialize)
+
+data ClientMetricsResp
+  = ClientMetricsResp RaftNodeMetrics
   deriving (Show, Generic, S.Serialize)
 
 --------------------------------------------------------------------------------
@@ -409,7 +437,7 @@ clientSendWrite
   -> RaftClientT s v m (Either (RaftClientSendError m v) ())
 clientSendWrite v = do
   gets raftClientSerialNum >>= \sn ->
-    clientSend (ClientWriteReq sn v)
+    clientSend (ClientWriteReq (ClientCmdReq sn v))
 
 -- | Send a write request to a specific raft node, ignoring the current
 -- leader. This function is used in testing.
@@ -420,7 +448,7 @@ clientSendWriteTo
   -> RaftClientT s v m (Either (RaftClientSendError m v) ())
 clientSendWriteTo nid v =
   gets raftClientSerialNum >>= \sn ->
-    clientSendTo nid (ClientWriteReq sn v)
+    clientSendTo nid (ClientWriteReq (ClientCmdReq sn v))
 
 -- | Send a request to the current leader. Nonblocking.
 clientSend

--- a/src/Raft/Config.hs
+++ b/src/Raft/Config.hs
@@ -39,8 +39,17 @@ data ConfigError
 
 resolveMetricsPort
   :: Maybe PortNumber
+  -> IO PortNumber
+resolveMetricsPort mPort = do
+  eMetricsPort <- resolveMetricsPortE mPort
+  case eMetricsPort of
+    Left err -> panic ("Error in raft node config: " <> show err)
+    Right port -> pure port
+
+resolveMetricsPortE
+  :: Maybe PortNumber
   -> IO (Either ConfigError PortNumber)
-resolveMetricsPort mPort =
+resolveMetricsPortE mPort =
   case mPort of
     Just port
       | port > 0 && port <= 65535 -> pure (Right port)

--- a/src/Raft/Config.hs
+++ b/src/Raft/Config.hs
@@ -5,18 +5,62 @@ module Raft.Config where
 import Protolude
 
 import Numeric.Natural (Natural)
+import Network.Socket
 
 import Raft.Types
 
+import System.Random (randomIO)
+
 -- | Configuration of a node in the cluster
 data RaftNodeConfig = RaftNodeConfig
-  { configNodeId :: NodeId -- ^ Node id of the running node
-  , configNodeIds :: NodeIds -- ^ Set of all other node ids in the cluster
-  , configElectionTimeout :: (Natural, Natural) -- ^ Range of times an election timeout can take
-  , configHeartbeatTimeout :: Natural -- ^ Heartbeat timeout timer
-  , configStorageState :: StorageState -- ^ Create a fresh DB or read from existing
-  , configMetricsPort :: Maybe Int
+  { raftConfigNodeId :: NodeId -- ^ Node id of the running node
+  , raftConfigNodeIds :: NodeIds -- ^ Set of all other node ids in the cluster
+  , raftConfigElectionTimeout :: (Natural, Natural) -- ^ Range of times an election timeout can take
+  , raftConfigHeartbeatTimeout :: Natural -- ^ Heartbeat timeout timer
+  , raftConfigStorageState :: StorageState -- ^ Create a fresh DB or read from existing
   } deriving (Show)
 
 data StorageState = New | Existing
   deriving Show
+
+data OptionalRaftNodeConfig = OptionalRaftNodeConfig
+  { raftConfigMetricsPort :: Maybe PortNumber
+  , raftConfigTimerSeed :: Maybe Int
+  } deriving (Show)
+
+defaultOptionalRaftNodeConfig :: OptionalRaftNodeConfig
+defaultOptionalRaftNodeConfig =
+  OptionalRaftNodeConfig Nothing Nothing
+
+data ConfigError
+  = InvalidMetricsPort
+  | NoFreePortAvailable
+  deriving (Show)
+
+resolveMetricsPort
+  :: Maybe PortNumber
+  -> IO (Either ConfigError PortNumber)
+resolveMetricsPort mPort =
+  case mPort of
+    Just port
+      | port > 0 && port <= 65535 -> pure (Right port)
+      | otherwise -> pure (Left InvalidMetricsPort)
+    Nothing -> do
+     let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
+     addrs <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "0")
+     case addrs of
+       [] -> pure (Left NoFreePortAvailable)
+       addr:_ -> do
+         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+         Network.Socket.bind sock (addrAddress addr)
+         freePort <- socketPort sock
+         close sock
+         pure (Right freePort)
+
+resolveTimerSeed
+  :: Maybe Int
+  -> IO Int
+resolveTimerSeed mSeed = do
+  case mSeed of
+    Just seed -> pure seed
+    Nothing -> randomIO

--- a/src/Raft/Config.hs
+++ b/src/Raft/Config.hs
@@ -39,32 +39,35 @@ data ConfigError
 
 resolveMetricsPort
   :: Maybe PortNumber
-  -> IO PortNumber
-resolveMetricsPort mPort = do
-  eMetricsPort <- resolveMetricsPortE mPort
-  case eMetricsPort of
-    Left err -> panic ("Error in raft node config: " <> show err)
-    Right port -> pure port
-
-resolveMetricsPortE
-  :: Maybe PortNumber
-  -> IO (Either ConfigError PortNumber)
-resolveMetricsPortE mPort =
+  -> IO (Maybe PortNumber)
+resolveMetricsPort mPort =
   case mPort of
-    Just port
-      | port > 0 && port <= 65535 -> pure (Right port)
-      | otherwise -> pure (Left InvalidMetricsPort)
-    Nothing -> do
-     let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
-     addrs <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "0")
-     case addrs of
-       [] -> pure (Left NoFreePortAvailable)
-       addr:_ -> do
-         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
-         Network.Socket.bind sock (addrAddress addr)
-         freePort <- socketPort sock
-         close sock
-         pure (Right freePort)
+    Nothing -> pure Nothing
+    Just port -> do
+      eMetricsPort <- resolveMetricsPortE port
+      case eMetricsPort of
+        Left err -> panic ("Error in raft node config: " <> show err)
+        Right port -> pure (Just port)
+
+-- | If the user specifies a port to fork the EKG server on, make sure the port
+-- is open and return the valid port number. If the user does not specify a port
+-- to run the monitoring server on, return Nothing.
+resolveMetricsPortE
+  :: PortNumber
+  -> IO (Either ConfigError PortNumber)
+resolveMetricsPortE port
+  | port > 0 && port <= 65535 = do
+      let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
+      addrs <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just (show port))
+      case addrs of
+        [] -> pure (Left NoFreePortAvailable)
+        addr:_ -> do
+          sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+          Network.Socket.bind sock (addrAddress addr)
+          freePort <- socketPort sock
+          close sock
+          pure (Right freePort)
+  | otherwise = pure (Left InvalidMetricsPort)
 
 resolveTimerSeed
   :: Maybe Int

--- a/src/Raft/Config.hs
+++ b/src/Raft/Config.hs
@@ -15,6 +15,7 @@ data RaftNodeConfig = RaftNodeConfig
   , configElectionTimeout :: (Natural, Natural) -- ^ Range of times an election timeout can take
   , configHeartbeatTimeout :: Natural -- ^ Heartbeat timeout timer
   , configStorageState :: StorageState -- ^ Create a fresh DB or read from existing
+  , configMetricsPort :: Maybe Int
   } deriving (Show)
 
 data StorageState = New | Existing

--- a/src/Raft/Handle.hs
+++ b/src/Raft/Handle.hs
@@ -19,6 +19,7 @@ import qualified Raft.Leader as Leader
 
 import Raft.Action
 import Raft.Event
+import Raft.Client
 import Raft.Transition
 import Raft.NodeState
 import Raft.Persistent
@@ -98,7 +99,8 @@ data RaftHandler ns sm v = RaftHandler
   , handleRequestVote :: RPCHandler ns sm RequestVote v
   , handleRequestVoteResponse :: RPCHandler ns sm RequestVoteResponse v
   , handleTimeout :: TimeoutHandler ns sm v
-  , handleClientRequest :: ClientReqHandler ns sm v
+  , handleClientReadRequest :: ClientReqHandler ns ClientReadReq sm v
+  , handleClientWriteRequest :: ClientReqHandler ns (ClientWriteReq v) sm v
   }
 
 followerRaftHandler :: (Show v, Serialize v) => RaftHandler 'Follower sm v
@@ -108,7 +110,8 @@ followerRaftHandler = RaftHandler
   , handleRequestVote = Follower.handleRequestVote
   , handleRequestVoteResponse = Follower.handleRequestVoteResponse
   , handleTimeout = Follower.handleTimeout
-  , handleClientRequest = Follower.handleClientRequest
+  , handleClientReadRequest = Follower.handleClientReadRequest
+  , handleClientWriteRequest = Follower.handleClientWriteRequest
   }
 
 candidateRaftHandler :: (Show v, Serialize v) => RaftHandler 'Candidate sm v
@@ -118,7 +121,8 @@ candidateRaftHandler = RaftHandler
   , handleRequestVote = Candidate.handleRequestVote
   , handleRequestVoteResponse = Candidate.handleRequestVoteResponse
   , handleTimeout = Candidate.handleTimeout
-  , handleClientRequest = Candidate.handleClientRequest
+  , handleClientReadRequest = Candidate.handleClientReadRequest
+  , handleClientWriteRequest = Candidate.handleClientWriteRequest
   }
 
 leaderRaftHandler :: (Show v, Serialize v) => RaftHandler 'Leader sm v
@@ -128,7 +132,8 @@ leaderRaftHandler = RaftHandler
   , handleRequestVote = Leader.handleRequestVote
   , handleRequestVoteResponse = Leader.handleRequestVoteResponse
   , handleTimeout = Leader.handleTimeout
-  , handleClientRequest = Leader.handleClientRequest
+  , handleClientReadRequest = Leader.handleClientReadRequest
+  , handleClientWriteRequest = Leader.handleClientWriteRequest
   }
 
 mkRaftHandler :: forall ns sm v. (Show v, Serialize v) => NodeState ns v -> RaftHandler ns sm v
@@ -152,9 +157,8 @@ handleEvent' initNodeState transitionEnv persistentState event =
         MessageEvent mev ->
           case mev of
             RPCMessageEvent rpcMsg -> handleRPCMessage rpcMsg
-            ClientRequestEvent cr -> handleClientRequest initNodeState cr
-        TimeoutEvent _ tout -> do
-          handleTimeout initNodeState tout
+            ClientRequestEvent clientReq -> handleClientRequest clientReq
+        TimeoutEvent _ tout -> handleTimeout initNodeState tout
   where
     RaftHandler{..} = mkRaftHandler initNodeState
 
@@ -169,3 +173,16 @@ handleEvent' initNodeState transitionEnv persistentState event =
           handleRequestVote initNodeState sender requestVote
         RequestVoteResponseRPC requestVoteResp ->
           handleRequestVoteResponse initNodeState sender requestVoteResp
+
+    handleClientRequest :: ClientRequest v -> TransitionM sm v (ResultState ns v)
+    handleClientRequest (ClientRequest cid cr) =
+      case cr of
+        ClientReadReq crr -> handleClientReadRequest initNodeState cid crr
+        ClientWriteReq cwr -> handleClientWriteRequest initNodeState cid cwr
+        -- All nodes handle this request the same
+        ClientMetricsReq _ -> do
+          respondClientMetrics cid
+          pure $ case initNodeState of
+            NodeFollowerState fs -> followerResultState Noop fs
+            NodeCandidateState cs -> candidateResultState Noop cs
+            NodeLeaderState ls -> leaderResultState Noop ls

--- a/src/Raft/Handle.hs
+++ b/src/Raft/Handle.hs
@@ -152,8 +152,7 @@ handleEvent' initNodeState transitionEnv persistentState event =
         MessageEvent mev ->
           case mev of
             RPCMessageEvent rpcMsg -> handleRPCMessage rpcMsg
-            ClientRequestEvent cr -> do
-              handleClientRequest initNodeState cr
+            ClientRequestEvent cr -> handleClientRequest initNodeState cr
         TimeoutEvent _ tout -> do
           handleTimeout initNodeState tout
   where

--- a/src/Raft/Leader.hs
+++ b/src/Raft/Leader.hs
@@ -13,7 +13,8 @@ module Raft.Leader (
   , handleRequestVote
   , handleRequestVoteResponse
   , handleTimeout
-  , handleClientRequest
+  , handleClientReadRequest
+  , handleClientWriteRequest
 ) where
 
 import Protolude
@@ -118,50 +119,42 @@ handleTimeout (NodeLeaderState ls) timeout =
       broadcast (SendAppendEntriesRPC aeData)
       pure (leaderResultState SendHeartbeat ls)
 
--- | The leader handles all client requests, responding with the current state
--- machine on a client read, and appending an entry to the log on a valid client
--- write.
-handleClientRequest :: (Show v, Serialize v) => ClientReqHandler 'Leader sm v
-handleClientRequest (NodeLeaderState ls@LeaderState{..}) (ClientRequest cid cr) = do
-    case cr of
-      ClientReadReq crr ->
-        leaderResultState HandleClientReq <$> handleClientReadReq crr
-      ClientWriteReq newSerial v ->
-        leaderResultState HandleClientReq <$> handleClientWriteReq newSerial v
-  where
-    handleClientReadReq crr = do
-      heartbeat <- mkAppendEntriesData ls (NoEntries (FromClientReadReq lsReadReqsHandled))
-      broadcast (SendAppendEntriesRPC heartbeat)
-      let clientReqData = ClientReadReqData cid crr
-      pure ls {
-        lsReadRequest =
-          Map.insert lsReadReqsHandled (clientReqData, 1) lsReadRequest
-      }
+handleClientReadRequest :: (Show v, Serialize v) => ClientReqHandler 'Leader ClientReadReq sm v
+handleClientReadRequest (NodeLeaderState ls@LeaderState{..}) cid crr = do
+  heartbeat <- mkAppendEntriesData ls (NoEntries (FromClientReadReq lsReadReqsHandled))
+  broadcast (SendAppendEntriesRPC heartbeat)
+  let clientReqData = ClientReadReqData cid crr
+  pure $ leaderResultState HandleClientReq ls {
+    lsReadRequest =
+      Map.insert lsReadReqsHandled (clientReqData, 1) lsReadRequest
+  }
 
-    handleClientWriteReq newSerial v =
-      case Map.lookup cid lsClientReqCache of
-        -- This is important case #1
-        Nothing -> handleNewEntry newSerial v
-        Just (currSerial, mResp)
-          | newSerial < currSerial -> do
-              let debugMsg s1 s2 = "Ignoring serial number " <> s1 <> ", current serial is " <> s2
-              logDebug $ debugMsg (show newSerial) (show currSerial)
-              pure ls
-          | currSerial == newSerial -> do
-              case mResp of
-                Nothing -> logDebug $ "Serial " <> show currSerial <> " already exists. Ignoring repeat request."
-                Just idx -> respondClientWrite cid idx newSerial
-              pure ls
-          -- This is important case #2, where newSerial > currSerial
-          | otherwise -> handleNewEntry newSerial v
-      where
-        handleNewEntry serial cmd = do
-          let lsClientReqCache' = Map.insert cid (serial, Nothing) lsClientReqCache
-          newLogEntry <- mkNewLogEntry cmd serial
-          appendLogEntries (Empty Seq.|> newLogEntry)
-          aeData <- mkAppendEntriesData ls (FromClientWriteReq newLogEntry)
-          broadcast (SendAppendEntriesRPC aeData)
-          pure ls { lsClientReqCache = lsClientReqCache' }
+handleClientWriteRequest :: (Show v, Serialize v) => ClientReqHandler 'Leader (ClientWriteReq v) sm v
+handleClientWriteRequest (NodeLeaderState ls@LeaderState{..}) cid (ClientCmdReq serial v) =
+  leaderResultState HandleClientReq <$>
+    case Map.lookup cid lsClientReqCache of
+      -- This is important case #1
+      Nothing -> handleNewEntry serial v
+      Just (currSerial, mResp)
+        | serial < currSerial -> do
+            let debugMsg s1 s2 = "Ignoring serial number " <> s1 <> ", current serial is " <> s2
+            logDebug $ debugMsg (show serial) (show currSerial)
+            pure ls
+        | currSerial == serial -> do
+            case mResp of
+              Nothing -> logDebug $ "Serial " <> show currSerial <> " already exists. Ignoring repeat request."
+              Just idx -> respondClientWrite cid idx serial
+            pure ls
+        -- This is important case #2, where serial > currSerial
+        | otherwise -> handleNewEntry serial v
+  where
+    handleNewEntry serial cmd = do
+      let lsClientReqCache' = Map.insert cid (serial, Nothing) lsClientReqCache
+      newLogEntry <- mkNewLogEntry cmd serial
+      appendLogEntries (Empty Seq.|> newLogEntry)
+      aeData <- mkAppendEntriesData ls (FromClientWriteReq newLogEntry)
+      broadcast (SendAppendEntriesRPC aeData)
+      pure ls { lsClientReqCache = lsClientReqCache' }
 
     mkNewLogEntry v sn = do
       currentTerm <- currentTerm <$> get
@@ -173,7 +166,6 @@ handleClientRequest (NodeLeaderState ls@LeaderState{..}) (ClientRequest cid cr) 
         , entryIssuer = ClientIssuer cid sn
         , entryPrevHash = hashLastLogEntry lsLastLogEntry
         }
-
 
 --------------------------------------------------------------------------------
 

--- a/src/Raft/Leader.hs
+++ b/src/Raft/Leader.hs
@@ -24,7 +24,7 @@ import Data.Sequence (Seq(Empty))
 import qualified Data.Set as Set
 import qualified Data.Sequence as Seq
 
-import Raft.Config (configNodeIds)
+import Raft.Config (raftConfigNodeIds)
 import Raft.NodeState
 import Raft.RPC
 import Raft.Action
@@ -72,7 +72,7 @@ handleAppendEntriesResponse ns@(NodeLeaderState ls) sender appendEntriesResp
   where
     handleReadReq :: Int -> LeaderState v -> TransitionM sm v (ResultState 'Leader v)
     handleReadReq n leaderState = do
-      networkSize <- Set.size <$> asks (configNodeIds . nodeConfig)
+      networkSize <- Set.size <$> asks (raftConfigNodeIds . nodeConfig)
       let initReadReqs = lsReadRequest leaderState
           (mCreqData, newReadReqs) =
             case Map.lookup n initReadReqs of

--- a/src/Raft/Metrics.hs
+++ b/src/Raft/Metrics.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Raft.Metrics
+( RaftNodeMetrics
+, getMetricsStore
+, getRaftNodeMetrics
+, incrInvalidCmdCounter
+, incrEventsHandledCounter
+) where
+
+import Protolude
+
+import qualified Control.Monad.Metrics as Metrics
+import qualified Control.Monad.Metrics.Internal as Metrics
+
+import qualified Data.HashMap.Strict as HashMap
+import Data.Serialize (Serialize)
+
+import qualified System.Metrics as EKG
+
+------------------------------------------------------------------------------
+-- Raft Node Metrics
+------------------------------------------------------------------------------
+
+data RaftNodeMetrics
+  = RaftNodeMetrics
+  { invalidCmdCounter :: Int64
+  , eventsHandledCounter :: Int64
+  } deriving (Show, Generic, Serialize)
+
+getMetricsStore :: (MonadIO m, Metrics.MonadMetrics m) => m EKG.Store
+getMetricsStore = Metrics._metricsStore <$> Metrics.getMetrics
+
+getRaftNodeMetrics :: (MonadIO m, Metrics.MonadMetrics m) => m RaftNodeMetrics
+getRaftNodeMetrics = do
+  metricsStore <- getMetricsStore
+  sample <- liftIO (EKG.sampleAll metricsStore)
+  pure RaftNodeMetrics
+    { invalidCmdCounter = lookupCounterValue InvalidCmdCounter sample
+    , eventsHandledCounter = lookupCounterValue EventsHandledCounter sample
+    }
+
+lookupCounterValue :: RaftNodeCounter -> EKG.Sample -> Int64
+lookupCounterValue counter sample =
+  case HashMap.lookup (show InvalidCmdCounter) sample of
+    Nothing -> 0
+    Just (EKG.Counter n) -> n
+    -- TODO Handle failure in a better way?
+    Just _ -> 0
+
+data RaftNodeCounter
+  = InvalidCmdCounter
+  | EventsHandledCounter
+  deriving Show
+
+incrRaftNodeCounter :: (MonadIO m, Metrics.MonadMetrics m) => RaftNodeCounter -> m ()
+incrRaftNodeCounter = Metrics.increment . show
+
+incrInvalidCmdCounter :: (MonadIO m, Metrics.MonadMetrics m) => m ()
+incrInvalidCmdCounter = incrRaftNodeCounter InvalidCmdCounter
+
+incrEventsHandledCounter :: (MonadIO m, Metrics.MonadMetrics m) => m ()
+incrEventsHandledCounter = incrRaftNodeCounter EventsHandledCounter

--- a/src/Raft/Monad.hs
+++ b/src/Raft/Monad.hs
@@ -128,7 +128,7 @@ instance MonadRaftFork m => MonadRaftFork (RaftT v m) where
     lift $ raftFork s (runRaftT raftState raftEnv m)
 
 instance Monad m => RaftLogger v (RaftT v m) where
-  loggerCtx = (,) <$> asks (configNodeId . raftNodeConfig) <*> get
+  loggerCtx = (,) <$> asks (raftConfigNodeId . raftNodeConfig) <*> get
 
 instance Monad m => Metrics.MonadMetrics (RaftT v m) where
   getMetrics = asks raftNodeMetrics
@@ -164,6 +164,9 @@ runRaftT raftNodeState raftEnv =
 ------------------------------------------------------------------------------
 -- Logging
 ------------------------------------------------------------------------------
+
+logInfo :: MonadIO m => Text -> RaftT v m ()
+logInfo msg = flip logInfoIO msg =<< asks raftNodeLogCtx
 
 logDebug :: MonadIO m => Text -> RaftT v m ()
 logDebug msg = flip logDebugIO msg =<< asks raftNodeLogCtx

--- a/src/Raft/Monad.hs
+++ b/src/Raft/Monad.hs
@@ -29,6 +29,9 @@ import Raft.NodeState
 import Test.DejaFu.Conc (ConcIO)
 import qualified Test.DejaFu.Types as TDT
 
+import qualified System.Remote.Monitoring as EKG
+import qualified System.Metrics as EKG
+
 --------------------------------------------------------------------------------
 -- Raft Monad Class
 --------------------------------------------------------------------------------
@@ -160,6 +163,22 @@ runRaftT
   -> m a
 runRaftT raftNodeState raftEnv =
   flip evalStateT raftNodeState . flip runReaderT raftEnv . unRaftT
+
+------------------------------------------------------------------------------
+-- Metrics
+------------------------------------------------------------------------------
+
+data InvalidCmdCounter = InvalidCmdCounter
+  deriving Show
+
+incrInvalidCmdCounter :: MonadIO m => RaftT v m ()
+incrInvalidCmdCounter = Metrics.increment (show InvalidCmdCounter)
+
+data EventsHandledCounter = EventsHandledCounter
+  deriving Show
+
+incrEventsHandledCounter :: MonadIO m => RaftT v m ()
+incrEventsHandledCounter = Metrics.increment "events.counter" -- (show EventsHandledCounter)
 
 ------------------------------------------------------------------------------
 -- Logging

--- a/src/Raft/NodeState.hs
+++ b/src/Raft/NodeState.hs
@@ -15,14 +15,7 @@ import Data.Sequence (Seq(..))
 
 import Raft.Client
 import Raft.Log
-import Raft.Client (SerialNum)
 import Raft.Types
-
-data Mode
-  = Follower
-  | Candidate
-  | Leader
-  deriving (Show)
 
 -- | All valid state transitions of a Raft node
 data Transition (init :: Mode) (res :: Mode) where

--- a/src/Raft/Transition.hs
+++ b/src/Raft/Transition.hs
@@ -25,6 +25,7 @@ import Raft.Config
 import Raft.Event
 import Raft.Log
 import Raft.Persistent
+import Raft.Monad
 import Raft.NodeState
 import Raft.RPC
 import Raft.Types
@@ -43,9 +44,10 @@ tellActions :: [Action sm v] -> TransitionM sm v ()
 tellActions as = tell as
 
 data TransitionEnv sm v = TransitionEnv
-  { nodeConfig :: !RaftNodeConfig
-  , stateMachine :: !sm
-  , nodeState :: !(RaftNodeState v)
+  { nodeConfig :: RaftNodeConfig
+  , stateMachine :: sm
+  , nodeState :: RaftNodeState v
+  , nodeMetrics :: RaftNodeMetrics
   }
 
 newtype TransitionM sm v a = TransitionM

--- a/src/Raft/Types.hs
+++ b/src/Raft/Types.hs
@@ -44,6 +44,16 @@ data CurrentLeader
   deriving stock (Show, Eq, Generic)
   deriving anyclass (Serialize)
 
+----------------
+-- Node State --
+----------------
+
+data Mode
+  = Follower
+  | Candidate
+  | Leader
+  deriving (Show, Read)
+
 ----------
 -- Term --
 ----------

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,3 +13,5 @@ extra-deps:
 - dejafu-1.12.0.0
 - tasty-dejafu-1.2.1.0
 - monad-metrics-0.2.1.2
+- ekg-0.4.0.15
+- ekg-json-0.1.0.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,4 @@ extra-deps:
 - concurrency-1.6.2.0
 - dejafu-1.12.0.0
 - tasty-dejafu-1.2.1.0
+- monad-metrics-0.2.1.2

--- a/test/QuickCheckStateMachine.hs
+++ b/test/QuickCheckStateMachine.hs
@@ -8,13 +8,11 @@
 module QuickCheckStateMachine where
 
 import           Control.Concurrent            (threadDelay)
-import           Control.Exception             (bracket)
 import           Control.Monad.IO.Class        (liftIO)
 import           Data.Bifunctor                (bimap)
 import           Data.Char                     (isDigit, toLower)
 import           Data.List                     (isInfixOf, (\\))
 import           Data.Maybe                    (isJust, isNothing)
-import qualified Data.Set                      as Set
 import           Data.TreeDiff                 (ToExpr)
 import           GHC.Generics                  (Generic, Generic1)
 import           Prelude                       hiding (notElem)
@@ -33,7 +31,7 @@ import           System.Timeout                (timeout)
 import           Test.QuickCheck               (Gen, Property, arbitrary,
                                                 elements, frequency,
                                                 noShrinking, shrink,
-                                                verboseCheck, withMaxSuccess,
+                                                withMaxSuccess,
                                                 (===))
 import           Test.QuickCheck.Monadic       (monadicIO)
 import           Test.StateMachine             (Concrete, GenSym, Logic (..),
@@ -43,7 +41,7 @@ import           Test.StateMachine             (Concrete, GenSym, Logic (..),
                                                 genSym, opaque, prettyCommands,
                                                 reference, runCommands, (.&&),
                                                 (.//), (.<), (.==), (.>=))
-import           Test.StateMachine.Types       (Command(..), Commands (..), Reference(..), Symbolic(..), Var(..))
+import           Test.StateMachine.Types       (Commands (..))
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Text.Read                     (readEither)
 

--- a/test/TestDejaFu.hs
+++ b/test/TestDejaFu.hs
@@ -281,14 +281,14 @@ initRaftTestEnvs eventChans clientRespChans = (testNodeEnvs, testStates)
       replicate (length nodeIds) (TestNodeState mempty initPersistentState)
 
 runTestNode :: TestNodeEnv -> TestNodeStates -> ConcIO ()
-runTestNode testEnv testState = do
-    runRaftTestM testEnv testState $
+runTestNode testEnv testState =
+    runRaftTestM testEnv testState $ do
+      raftEnv <- initializeRaftEnv eventChan dummyTimer dummyTimer (testRaftNodeConfig testEnv) NoLogs
       runRaftT initRaftNodeState raftEnv $
         handleEventLoop (mempty :: Store)
   where
     nid = configNodeId (testRaftNodeConfig testEnv)
     Just eventChan = Map.lookup nid (testNodeEventChans testEnv)
-    raftEnv = RaftEnv eventChan dummyTimer dummyTimer (testRaftNodeConfig testEnv) NoLogs
     dummyTimer = pure ()
 
 forkTestNodes :: [TestNodeEnv] -> TestNodeStates -> ConcIO [ThreadId ConcIO]

--- a/test/TestDejaFu.hs
+++ b/test/TestDejaFu.hs
@@ -114,7 +114,7 @@ instance Exception RaftTestError
 throwTestErr = throw . RaftTestError
 
 askSelfNodeId :: RaftTestM NodeId
-askSelfNodeId = asks (configNodeId . testRaftNodeConfig)
+askSelfNodeId = asks (raftConfigNodeId . testRaftNodeConfig)
 
 lookupNodeEventChan :: NodeId -> RaftTestM TestEventChan
 lookupNodeEventChan nid = do
@@ -287,7 +287,7 @@ runTestNode testEnv testState =
       runRaftT initRaftNodeState raftEnv $
         handleEventLoop (mempty :: Store)
   where
-    nid = configNodeId (testRaftNodeConfig testEnv)
+    nid = raftConfigNodeId (testRaftNodeConfig testEnv)
     Just eventChan = Map.lookup nid (testNodeEventChans testEnv)
     dummyTimer = pure ()
 

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -56,25 +56,25 @@ pairMsToMicroS = bimap msToMicroS msToMicroS
 
 testConfig0, testConfig1, testConfig2 :: RaftNodeConfig
 testConfig0 = RaftNodeConfig
-  { configNodeId = node0
-  , configNodeIds = nodeIds
-  , configElectionTimeout = pairMsToMicroS (150, 300)
-  , configHeartbeatTimeout = msToMicroS 50
-  , configStorageState = New
+  { raftConfigNodeId = node0
+  , raftConfigNodeIds = nodeIds
+  , raftConfigElectionTimeout = pairMsToMicroS (150, 300)
+  , raftConfigHeartbeatTimeout = msToMicroS 50
+  , raftConfigStorageState = New
   }
 testConfig1 = RaftNodeConfig
-  { configNodeId = node1
-  , configNodeIds = nodeIds
-  , configElectionTimeout = pairMsToMicroS (150, 300)
-  , configHeartbeatTimeout = msToMicroS 50
-  , configStorageState = New
+  { raftConfigNodeId = node1
+  , raftConfigNodeIds = nodeIds
+  , raftConfigElectionTimeout = pairMsToMicroS (150, 300)
+  , raftConfigHeartbeatTimeout = msToMicroS 50
+  , raftConfigStorageState = New
   }
 testConfig2 = RaftNodeConfig
-  { configNodeId = node2
-  , configNodeIds = nodeIds
-  , configElectionTimeout = pairMsToMicroS (150, 300)
-  , configHeartbeatTimeout = msToMicroS 50
-  , configStorageState = New
+  { raftConfigNodeId = node2
+  , raftConfigNodeIds = nodeIds
+  , raftConfigElectionTimeout = pairMsToMicroS (150, 300)
+  , raftConfigHeartbeatTimeout = msToMicroS 50
+  , raftConfigStorageState = New
   }
 
 -- | Zip maps using function. Throws away items left and right


### PR DESCRIPTION
A per discussion earlier today, this PR adds individual raft node metrics using the `monad-metrics` library. By design, the library exposes a `MonadMetric` typeclass that ultimately needs IO as the base monad. This typeclass allows for the addition of various types of metrics:
- `Counter`: a key value store mapping `Text` values to their "counts"
- `Distribution`: a running statistical analysis of values recorded at arbitrary times
- `Label`:  a key value store mapping `Text` values to other `Text` values

Ultimately, these metrics will be read by client programs that wish to enforce that certain node-level properties hold under specific conditions. This PR should decide upon an API for querying these node metrics. There are several ways to do this, each with tradeoffs. For brevity, I will simply list the means instead of also discussing their tradeoffs:

- Forking an thread that handle REST style requests, returning a JSON value of the node metrics to the issuer.
- Adding a new `ClientRequest` value that all nodes service as a request and respond to the issuer through use of typeclass functions similar to or exactly as `RaftSendClient`, `RaftRecvClient`, and `RaftClientSend`, and `RaftClientRecv`.

The initial commit of this PR achieves the following:
- Adds a `MonadMetric` instance to the `RaftT` monad 
- Initializes a `Metric` value and adding it to the `RaftEnv` for use within `RaftT` computations
- Increments a "Invalid Command" counter that counts the number of invalid commands seen by a node.
- Computes a distributed over the amount of time that each `handleAction` function call makes (note: this inhibits performance a little, and is added for demonstration purposes).