### PR TITLE
[Feature] Add LastLogEntry hash metric label

### DIFF
--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -408,7 +408,7 @@ handleAction action = do
           -- Update the last log entry index metrics
           case midx of
             Nothing -> pure ()
-            Just idx -> Metrics.setLastLogIndexGauge idx
+            Just idx -> Metrics.setLastLogEntryIndexGauge idx
           -- Update the last log entry data
           modify $ \(RaftNodeState ns) ->
             RaftNodeState (setLastLogEntry ns entries)

--- a/src/Raft/Follower.hs
+++ b/src/Raft/Follower.hs
@@ -27,7 +27,7 @@ import Raft.RPC
 import Raft.Client
 import Raft.Event
 import Raft.Persistent
-import Raft.Log (entryIndex)
+import Raft.Log
 import Raft.Transition
 import Raft.Types
 

--- a/src/Raft/Leader.hs
+++ b/src/Raft/Leader.hs
@@ -32,7 +32,7 @@ import Raft.Action
 import Raft.Client
 import Raft.Event
 import Raft.Persistent
-import Raft.Log (Entry(..), EntryIssuer(..), EntryValue(..))
+import Raft.Log
 import Raft.Transition
 import Raft.Types
 

--- a/src/Raft/Metrics.hs
+++ b/src/Raft/Metrics.hs
@@ -3,6 +3,7 @@
 
 module Raft.Metrics
 ( RaftNodeMetrics
+, defaultRaftNodeMetrics
 , getMetricsStore
 , getRaftNodeMetrics
 , setNodeStateLabel
@@ -39,6 +40,16 @@ data RaftNodeMetrics
   , lastLogIndexGauge :: Int64
   , commitIndexGauge :: Int64
   } deriving (Show, Generic, Serialize)
+
+defaultRaftNodeMetrics :: RaftNodeMetrics
+defaultRaftNodeMetrics = RaftNodeMetrics
+  { invalidCmdCounter = 0
+  , eventsHandledCounter = 0
+  , nodeStateLabel = "Follower"
+  , lastLogHashLabel = toS (unEntryHash genesisHash)
+  , lastLogIndexGauge = 0
+  , commitIndexGauge = 0
+  }
 
 getMetricsStore :: (MonadIO m, Metrics.MonadMetrics m) => m EKG.Store
 getMetricsStore = Metrics._metricsStore <$> Metrics.getMetrics

--- a/src/Raft/Metrics.hs
+++ b/src/Raft/Metrics.hs
@@ -23,7 +23,7 @@ import Data.Serialize (Serialize)
 
 import qualified System.Metrics as EKG
 
-import Raft.Log (LastLogEntry, EntryHash(..), hashLastLogEntry)
+import Raft.Log (LastLogEntry, EntryHash(..), hashLastLogEntry, genesisHash)
 import Raft.Types (Index, Mode(..))
 
 ------------------------------------------------------------------------------
@@ -51,7 +51,7 @@ getRaftNodeMetrics = do
     { invalidCmdCounter = lookupCounterValue InvalidCmdCounter sample
     , eventsHandledCounter = lookupCounterValue EventsHandledCounter sample
     , nodeStateLabel = toS (lookupLabelValue NodeStateLabel sample)
-    , lastLogHashLabel = toS (lookupLabelValue LastLogEntryHashLabel sample)
+    , lastLogHashLabel = toS (lookupLastLogEntryHashLabel sample)
     , lastLogIndexGauge = lookupGaugeValue LastLogEntryIndexGauge sample
     , commitIndexGauge = lookupGaugeValue CommitIndexGauge sample
     }
@@ -87,6 +87,12 @@ setLastLogEntryHashLabel
   => LastLogEntry v
   -> m ()
 setLastLogEntryHashLabel = setRaftNodeLabel LastLogEntryHashLabel . toS . unEntryHash . hashLastLogEntry
+
+lookupLastLogEntryHashLabel :: EKG.Sample -> Text
+lookupLastLogEntryHashLabel sample =
+    case HashMap.lookup (show LastLogEntryHashLabel) sample of
+      Just (EKG.Label hashAsText) -> hashAsText
+      _ -> toS . unEntryHash $ genesisHash
 
 --------------------------------------------------------------------------------
 -- Gauges

--- a/src/Raft/NodeState.hs
+++ b/src/Raft/NodeState.hs
@@ -10,7 +10,6 @@ module Raft.NodeState where
 
 import Protolude
 
-import qualified Data.Serialize as S
 import Data.Sequence (Seq(..))
 
 import Raft.Client
@@ -102,34 +101,6 @@ data NodeState (a :: Mode) v where
   NodeLeaderState :: LeaderState v -> NodeState 'Leader v
 
 deriving instance Show v => Show (NodeState s v)
-
-data LastLogEntry v
-  = LastLogEntry (Entry v)
-  | NoLogEntries
-  deriving (Show)
-
-hashLastLogEntry :: S.Serialize v => LastLogEntry v -> EntryHash
-hashLastLogEntry = \case
-  LastLogEntry e -> hashEntry e
-  NoLogEntries -> genesisHash
-
-lastLogEntryIndex :: LastLogEntry v -> Index
-lastLogEntryIndex = \case
-  LastLogEntry e -> entryIndex e
-  NoLogEntries -> index0
-
-lastLogEntryTerm :: LastLogEntry v -> Term
-lastLogEntryTerm = \case
-  LastLogEntry e -> entryTerm e
-  NoLogEntries -> term0
-
-lastLogEntryIndexAndTerm :: LastLogEntry v -> (Index, Term)
-lastLogEntryIndexAndTerm lle = (lastLogEntryIndex lle, lastLogEntryTerm lle)
-
-lastLogEntryIssuer :: LastLogEntry v -> Maybe EntryIssuer
-lastLogEntryIssuer = \case
-  LastLogEntry e -> Just (entryIssuer e)
-  NoLogEntries -> Nothing
 
 data FollowerState v = FollowerState
   { fsCurrentLeader :: CurrentLeader


### PR DESCRIPTION
This PR add the last log entry hash metric, used for testing if the network has converged and is in a steady state where all nodes have the same log entries.

Subsequently, I had to move the `LastLogEntry` datatype definition to the `Raft.Log` module to prevent cyclic imports.