### PR TITLE
[Bug Fix] Fix UpdateClientReqCacheFrom action handler

### DIFF
--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -296,8 +296,6 @@ handleEventLoop initStateMachine = do
           logDebug $ "[NodeState]: " <> show raftNodeState
           logDebug $ "[State Machine]: " <> show stateMachine
           logDebug $ "[Persistent State]: " <> show persistentState
-          Right (entries :: Entries v) <- lift $ readLogEntriesFrom index0
-          logDebug $ "[LogEntries]: \n" <> T.intercalate "\n   " (map show (toList entries))
           -- Perform core state machine transition, handling the current event
           nodeConfig <- asks raftNodeConfig
           raftNodeMetrics <- Metrics.getRaftNodeMetrics

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -415,7 +415,8 @@ handleAction action = do
       RaftNodeState ns <- get
       case ns of
         NodeLeaderState ls@LeaderState{..} -> do
-          eentries <- lift (readLogEntriesFrom idx)
+          let idxInterval = IndexInterval (Just idx) (Just lsCommitIndex)
+          eentries <- lift (readEntriesByIndices idxInterval)
           case eentries of
             Left err -> throwM err
             Right (entries :: Entries v) ->  do

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -111,6 +111,7 @@ import Control.Monad.Fail
 import Control.Monad.Catch
 
 import qualified Data.Map as Map
+import qualified Data.Text as T
 import Data.Serialize (Serialize)
 import Data.Sequence (Seq(..), singleton)
 import Data.Time.Clock.System (getSystemTime)
@@ -228,6 +229,8 @@ handleEventLoop
      , RaftSendClient m sm v
      , RaftLog m v
      , RaftLogExceptions m
+     , RaftReadLog m v
+     , Show v
      , RaftPersist m
      , Exception (RaftPersistError m)
      )
@@ -293,6 +296,8 @@ handleEventLoop initStateMachine = do
           logDebug $ "[NodeState]: " <> show raftNodeState
           logDebug $ "[State Machine]: " <> show stateMachine
           logDebug $ "[Persistent State]: " <> show persistentState
+          Right (entries :: Entries v) <- lift $ readLogEntriesFrom index0
+          logDebug $ "[LogEntries]: \n" <> T.intercalate "\n   " (map show (toList entries))
           -- Perform core state machine transition, handling the current event
           nodeConfig <- asks raftNodeConfig
           raftNodeMetrics <- Metrics.getRaftNodeMetrics

--- a/src/Raft/Handle.hs
+++ b/src/Raft/Handle.hs
@@ -53,18 +53,12 @@ handleEvent raftNodeState@(RaftNodeState initNodeState) transitionEnv persistent
             -- If RPC request or response contains term T > currentTerm: set
             -- currentTerm = T, convert to follower
             currentTerm <- gets currentTerm
-            if (currentTerm < rpcTerm rpc) ||
-               (currentTerm == rpcTerm rpc && isCandidate initNodeState && isAppendEntriesRPC rpc)
-               -- ^ While waiting for votes, a candidate may receive an
-               -- AppendEntries RPC from another server claiming to be
-               -- leader. If the leader’s term (included in its RPC) is at least
-               -- as large as the candidate’s current term, then the candidate
-               -- recognizes the leader as legitimate and returns to follower
-               -- state.
+            if (currentTerm < rpcTerm rpc)
               then mkNewRaftNodeState rpc
               else pure raftNodeState
         _ -> ((raftNodeState, []), persistentState, mempty)
 
+    mkNewRaftNodeState :: RPC v -> TransitionM sm v (RaftNodeState v)
     mkNewRaftNodeState rpc =
       case convertToFollower initNodeState of
         ResultState _ nodeState -> do

--- a/src/Raft/Log.hs
+++ b/src/Raft/Log.hs
@@ -47,6 +47,7 @@ module Raft.Log (
   updateLog,
   clientReqData,
   readEntries,
+  readEntriesByIndices,
 
 ) where
 

--- a/src/Raft/RPC.hs
+++ b/src/Raft/RPC.hs
@@ -38,6 +38,14 @@ data RPC v
   | RequestVoteResponseRPC RequestVoteResponse
   deriving (Show, Generic, Serialize)
 
+isAppendEntriesRPC :: RPC v -> Bool
+isAppendEntriesRPC rpc =
+  case rpc of
+    AppendEntriesRPC _ -> True
+    AppendEntriesResponseRPC _ -> False
+    RequestVoteRPC _ -> False
+    RequestVoteResponseRPC _ -> False
+
 class RPCType a v where
   toRPC :: a -> RPC v
 

--- a/src/Raft/RPC.hs
+++ b/src/Raft/RPC.hs
@@ -38,14 +38,6 @@ data RPC v
   | RequestVoteResponseRPC RequestVoteResponse
   deriving (Show, Generic, Serialize)
 
-isAppendEntriesRPC :: RPC v -> Bool
-isAppendEntriesRPC rpc =
-  case rpc of
-    AppendEntriesRPC _ -> True
-    AppendEntriesResponseRPC _ -> False
-    RequestVoteRPC _ -> False
-    RequestVoteResponseRPC _ -> False
-
 class RPCType a v where
   toRPC :: a -> RPC v
 


### PR DESCRIPTION
This PR fixes the bug in the `UpdateClientReqCacheFrom` action handler in `Raft.hs` such that the leader only responds to the client requests that are between the old commit index and the new commit index.