### PR TITLE
[Bug/Feature] Second state-machine for command validation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog for raft
 
+## 0.6.0.0
+
+- API change: Added a type parameter to many internal datatypes and type
+  classes, most importantly of which the `RaftT` monad transformer with which
+  raft nodes are spawned.
+
+- Bug Fix: Validation of log entries upon appending them to a node's local log 
+  no longer causes the nodes to crash; The leader now properly validates log
+  entries before replicating them to all followers.
+
 ## 0.5.0.0
 
 - Feature: Client write requests are now validated by the leader before being

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 0.6.0.0
 
+- Feature: Optimized (reduced) the number of RPC messages sent between leader 
+  and follower for the follower to reconcile a log disparity resulting from
+  network partitions.
+
 - API change: Added a type parameter to many internal datatypes and type
   classes, most importantly of which the `RaftT` monad transformer with which
   raft nodes are spawned.

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name:                libraft
 synopsis:            Raft consensus algorithm
 category:            Distributed Systems
-version:             0.4.1.0
+version:             0.6.0.0
 github:              "adjoint-io/raft"
 license:             BSD3
 author:              "Adjoint Inc."

--- a/src/Raft.hs
+++ b/src/Raft.hs
@@ -417,7 +417,7 @@ handleAction action = do
           case mLastLogEntry of
             Nothing -> pure ()
             Just lastLogEntry -> do
-              Metrics.setLastLogEntryIndexGauge (lastLogEntryIndex lastLogEntry)
+              Metrics.setLastLogEntryIndexGauge lastLogEntry
               Metrics.setLastLogEntryHashLabel lastLogEntry
           -- Update the last log entry data
           modify $ \(RaftNodeState ns) ->

--- a/src/Raft/Client.hs
+++ b/src/Raft/Client.hs
@@ -54,7 +54,6 @@ module Raft.Client
 , initRaftClientState
 
 , RaftClientT(..)
-, unRaftClientT
 , runRaftClientT
 
 , RaftClientError(..)

--- a/src/Raft/Follower.hs
+++ b/src/Raft/Follower.hs
@@ -72,7 +72,7 @@ handleAppendEntries ns@(NodeFollowerState fs) sender ae@AppendEntries{..} = do
         }
   pure (followerResultState Noop newFollowerState)
   where
-    updateCommitIndex :: FollowerState v -> FollowerState v
+    updateCommitIndex :: FollowerState sm v -> FollowerState sm v
     updateCommitIndex followerState =
       case aeEntries of
         Empty -> followerState
@@ -80,11 +80,11 @@ handleAppendEntries ns@(NodeFollowerState fs) sender ae@AppendEntries{..} = do
           let newCommitIndex = min aeLeaderCommit (entryIndex e)
           in followerState { fsCommitIndex = newCommitIndex }
 
-    updateLeader :: FollowerState v -> FollowerState v
+    updateLeader :: FollowerState sm v -> FollowerState sm v
     updateLeader followerState = followerState { fsCurrentLeader = CurrentLeader (LeaderId sender) }
 
 -- | Decide if entries given can be applied
-shouldApplyAppendEntries :: Term -> FollowerState v -> AppendEntries v -> AppendEntriesResponseStatus
+shouldApplyAppendEntries :: Term -> FollowerState sm v -> AppendEntries v -> AppendEntriesResponseStatus
 shouldApplyAppendEntries currentTerm fs AppendEntries{..} =
   if aeTerm < currentTerm
     -- 1. Reply false if term < currentTerm

--- a/src/Raft/Log.hs
+++ b/src/Raft/Log.hs
@@ -101,6 +101,12 @@ data Entry v = Entry
 
 type Entries v = Seq (Entry v)
 
+lastLogEntry :: Entries v -> LastLogEntry v
+lastLogEntry entries =
+  case entries of
+    Empty -> NoLogEntries
+    _ :|> e -> LastLogEntry e
+
 lastEntryIndex :: Entries v -> Maybe Index
 lastEntryIndex entries =
   case entries of
@@ -270,7 +276,7 @@ updateLog
      , RaftWriteLog m v, Exception (RaftWriteLogError m)
      )
   => Entries v
-  -> m (Either (RaftLogError m) (Maybe Index))
+  -> m (Either (RaftLogError m) (Maybe (LastLogEntry v)))
 updateLog entries =
   case entries of
     Empty -> pure (Right Nothing)
@@ -282,7 +288,7 @@ updateLog entries =
           eRes <- first RaftLogWriteError <$> writeLogEntries entries
           case eRes of
             Left err -> pure (Left err)
-            Right () -> pure (Right (lastEntryIndex entries))
+            Right () -> pure (Right (Just (lastLogEntry entries)))
 
 
 --------------------------------------------------------------------------------

--- a/src/Raft/Metrics.hs
+++ b/src/Raft/Metrics.hs
@@ -24,7 +24,7 @@ import Data.Serialize (Serialize)
 
 import qualified System.Metrics as EKG
 
-import Raft.Log (LastLogEntry, EntryHash(..), hashLastLogEntry, genesisHash)
+import Raft.Log (LastLogEntry, EntryHash(..), hashLastLogEntry, lastLogEntryIndex, genesisHash)
 import Raft.Types (Index, Mode(..))
 
 ------------------------------------------------------------------------------
@@ -128,8 +128,8 @@ lookupGaugeValue gauge sample =
 setRaftNodeGauge :: (MonadIO m, Metrics.MonadMetrics m) => RaftNodeGauge -> Int -> m ()
 setRaftNodeGauge gauge n = Metrics.gauge (show gauge) n
 
-setLastLogEntryIndexGauge :: (MonadIO m, Metrics.MonadMetrics m) => Index -> m ()
-setLastLogEntryIndexGauge = setRaftNodeGauge LastLogEntryIndexGauge . fromIntegral
+setLastLogEntryIndexGauge :: (MonadIO m, Metrics.MonadMetrics m) => LastLogEntry v -> m ()
+setLastLogEntryIndexGauge = setRaftNodeGauge LastLogEntryIndexGauge . fromIntegral . lastLogEntryIndex
 
 setCommitIndexGauge :: (MonadIO m, Metrics.MonadMetrics m) => Index -> m ()
 setCommitIndexGauge = setRaftNodeGauge CommitIndexGauge . fromIntegral

--- a/test/RaftTestT.hs
+++ b/test/RaftTestT.hs
@@ -15,7 +15,6 @@ import Protolude hiding
   (STM, TVar, TChan, newTChan, readMVar, readTChan, writeTChan, atomically, killThread, ThreadId, readTVar, writeTVar)
 
 import Data.Sequence (Seq(..), (><), dropWhileR, (!?))
-import qualified Data.Sequence as Seq
 import qualified Data.Map as Map
 import qualified Data.Serialize as S
 import Numeric.Natural
@@ -30,7 +29,6 @@ import Control.Concurrent.Classy.STM.TChan
 import Control.Concurrent.Classy.STM.TVar
 
 import Test.DejaFu.Conc (ConcIO)
-import Test.Tasty.HUnit
 
 import Raft
 import Raft.Client

--- a/test/TestDejaFu.hs
+++ b/test/TestDejaFu.hs
@@ -18,17 +18,14 @@ import Protolude hiding
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Maybe as Maybe
-import Test.QuickCheck
-
 
 import Test.DejaFu hiding (get, ThreadId)
 import Test.DejaFu.Internal (Settings(..))
 import Test.DejaFu.Conc hiding (ThreadId)
 import Test.Tasty
-import Test.Tasty.HUnit
 import Test.Tasty.DejaFu hiding (get)
 
-import System.Random (mkStdGen, newStdGen)
+import System.Random (mkStdGen)
 import Data.List
 import TestUtils
 import RaftTestT

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -10,26 +10,26 @@ import qualified Data.Map.Merge.Lazy as Merge
 import Raft
 import Raft.Config
 
-isRaftLeader :: RaftNodeState v -> Bool
+isRaftLeader :: RaftNodeState sm v -> Bool
 isRaftLeader (RaftNodeState rns) = isLeader rns
 
-isRaftCandidate :: RaftNodeState v -> Bool
+isRaftCandidate :: RaftNodeState sm v -> Bool
 isRaftCandidate (RaftNodeState rns) = isCandidate rns
 
-isRaftFollower :: RaftNodeState v -> Bool
+isRaftFollower :: RaftNodeState sm v -> Bool
 isRaftFollower (RaftNodeState rns) = isFollower rns
 
-checkCurrentLeader :: RaftNodeState v -> CurrentLeader
+checkCurrentLeader :: RaftNodeState sm v -> CurrentLeader
 checkCurrentLeader (RaftNodeState (NodeFollowerState FollowerState{..})) = fsCurrentLeader
 checkCurrentLeader (RaftNodeState (NodeCandidateState _)) = NoLeader
 checkCurrentLeader (RaftNodeState (NodeLeaderState _)) = NoLeader
 
-getLastAppliedLog :: RaftNodeState v -> Index
+getLastAppliedLog :: RaftNodeState sm v -> Index
 getLastAppliedLog (RaftNodeState (NodeFollowerState FollowerState{..})) = fsLastApplied
 getLastAppliedLog (RaftNodeState (NodeCandidateState CandidateState{..})) = csLastApplied
 getLastAppliedLog (RaftNodeState (NodeLeaderState LeaderState{..})) = lsLastApplied
 
-getCommittedLogIndex :: RaftNodeState v -> Index
+getCommittedLogIndex :: RaftNodeState sm v -> Index
 getCommittedLogIndex (RaftNodeState (NodeFollowerState FollowerState{..})) = fsCommitIndex
 getCommittedLogIndex (RaftNodeState (NodeCandidateState CandidateState{..})) = csCommitIndex
 getCommittedLogIndex (RaftNodeState (NodeLeaderState LeaderState{..})) = lsCommitIndex


### PR DESCRIPTION
Please see issue #135

For those too lazy to visit the issue, this PR accomplishes the following in brief:
- Adds a second state machine to track the _tentative_ state machine on leader nodes; i.e. the state machine that is the cumulation of _all_ state machine commands that have been issued but not necessarily fully replicated

Implementation details:
- Added a `sm` parameter to the `LeaderState`, `CandidateState`, `FollowerState`, `RaftNodeState`, `ResultState`, `RaftLoggerT`, and `RaftT` datatypes
- Added a `sm` parameter to the `RaftLogger` typeclass (to pass to the `RaftNodeState` datatype in the `loggerCtx` result

Subsequently, a majority of the line changes in this PR are a result of propagating the `sm` type parameter through all relevant datatypes. This was done because the `LeaderState sm v` type deep within the implementation needed access to this type variable that describes the type of the underlying shared state machine.
