### PR TITLE
Windows Support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,21 +447,22 @@ have further insight.
 
     - On terminal 1:
 
-    ```$ stack exec raft-example node fresh file localhost:3001 localhost:3002 localhost:3003```
+    ```$ stack exec -- raft-example node --reset localhost:3001 --nodes "localhost:3002 localhost:3003"```
 
     - On terminal 2:
 
-    ```$ stack exec raft-example node fresh file localhost:3002 localhost:3001 localhost:3003```
+    ```$ stack exec -- raft-example node --reset localhost:3002 --nodes "localhost:3001 localhost:3003"```
 
     - On terminal 3:
 
-    ```$ stack exec raft-example node fresh file localhost:3003 localhost:3001 localhost:3002```
+    ```$ stack exec -- raft-example node --reset localhost:3003 --nodes "localhost:3001 localhost:3002"```
 
     The first node spawned should become candidate once its election's timer
     times out and request votes to other nodes. It will then become the leader,
     once it receives a majority of votes and will broadcast messages to all
     nodes at each heartbeat.
 
+    **Pending testing/verification the below for compatability with the new versions**
     **Note:** If you want to run a raft example node with _existing_ persistent data,
     pass the `existing` command line option to the `raft-example` program instead
     of `fresh`:

--- a/app/Node.hs
+++ b/app/Node.hs
@@ -1,45 +1,41 @@
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Node where
-import Protolude
+import           Protolude
 
-import Control.Concurrent.Lifted (fork)
-import Control.Concurrent.STM.TChan
-import Control.Concurrent.STM.TVar
+import           Control.Concurrent.Lifted      ( fork )
+import           Control.Concurrent.STM.TChan
+import           Control.Concurrent.STM.TVar
 
-import Control.Monad.Fail
-import Control.Monad.Catch
+import           Control.Monad.Fail
+import           Control.Monad.Catch
 
-import qualified Data.Set as Set
-import qualified Data.Map as Map
+import qualified Data.Set                      as Set
+import qualified Data.Map                      as Map
 
-import System.FilePath ((</>))
-import qualified System.Directory as Directory
+import           System.FilePath                ( (</>) )
+import qualified System.Directory              as Directory
 
-import Database.PostgreSQL.Simple
+import           Database.PostgreSQL.Simple
 
-import Raft
-import Raft.Monad
-import Raft.Config
-import Raft.Log
-import Raft.Log.PostgreSQL
+import           Raft
+import           Raft.Monad
+import           Raft.Config
+import           Raft.Log
+import           Raft.Log.PostgreSQL
 
-import Examples.Raft.Socket.Node
-import qualified Examples.Raft.Socket.Common as RS
-import Examples.Raft.FileStore.Log
-import Examples.Raft.FileStore.Persistent
+import           Examples.Raft.Socket.Node
+import qualified Examples.Raft.Socket.Common   as RS
+import           Examples.Raft.FileStore.Log
+import           Examples.Raft.FileStore.Persistent
 
-import Store
-import RaftExampleT
+import           Store
+import           RaftExampleT
 
 --------------------
 -- Node --
@@ -49,62 +45,72 @@ data LogStorage = FileStore | PostgreSQL ConnectInfo
 
 nodeMain :: StorageState -> LogStorage -> NodeId -> [NodeId] -> IO ()
 nodeMain storageState storageType nid nids = do
-      nodeDir <- mkExampleDir nid
-      case storageState of
-        New -> cleanStorage nodeDir storageType
-        Existing -> pure ()
+  nodeDir <- mkExampleDir nid
+  case storageState of
+    New      -> cleanStorage nodeDir storageType
+    Existing -> pure ()
 
-      nSocketEnv <- initSocketEnv nid
-      nPersistFile <- RaftPersistFile <$> persistentFilePath nid
+  nSocketEnv   <- initSocketEnv nid
+  nPersistFile <- RaftPersistFile <$> persistentFilePath nid
 
-      let (host, port) = RS.nidToHostPort (toS nid)
-      -- Launch the server receiving connections from raft other nodes
-      fork $ flip runReaderT nSocketEnv . unRaftSocketT $
-        acceptConnections host port
+  let (host, port) = RS.nidToHostPort (toS nid)
+  -- Launch the server receiving connections from raft other nodes
+  fork $ flip runReaderT nSocketEnv . unRaftSocketT $ acceptConnections host
+                                                                        port
 
-      case storageType of
-        FileStore -> do
-          nLogsFile <- RaftLogFile <$> logsFilePath nid
-          runRaftExampleT $
-            runRaftLogFileStoreT nLogsFile $
-              runRaftNode' nSocketEnv nPersistFile
-        PostgreSQL connInfo -> do
-          runRaftExampleT $
-            runRaftPostgresT connInfo $
-              runRaftNode' nSocketEnv nPersistFile
-   where
-      runRaftNode'
-        :: ( MonadIO m, MonadRaft StoreCmd m, MonadFail m, MonadMask m
-           , MonadRaft StoreCmd m, RaftStateMachine m Store StoreCmd
-           , RaftInitLog m StoreCmd, RaftReadLog m StoreCmd, RaftWriteLog m StoreCmd, RaftDeleteLog m StoreCmd
-           , Exception (RaftInitLogError m), Exception (RaftReadLogError m)
-           , Exception (RaftWriteLogError m), Exception (RaftDeleteLogError m)
-           , Typeable m
-           )
-        => NodeSocketEnv Store StoreCmd
-        -> RaftPersistFile
-        -> m ()
-      runRaftNode' nSocketEnv nPersistFile =
-        runRaftSocketT nSocketEnv $
-          runRaftPersistFileStoreT nPersistFile $ do
-            let allNodeIds = Set.fromList (nid : nids)
-            let nodeConfig = RaftNodeConfig
-                              { raftConfigNodeId = toS nid
-                              , raftConfigNodeIds = allNodeIds
-                              -- These are recommended timeouts from the original
-                              -- raft paper and the ARC report.
-                              , raftConfigElectionTimeout = (150000, 300000)
-                              , raftConfigHeartbeatTimeout = 50000
-                              , raftConfigStorageState = storageState
-                              }
-            runRaftNode nodeConfig defaultOptionalRaftNodeConfig (LogCtx LogStdout Debug) (mempty :: Store)
+  case storageType of
+    FileStore -> do
+      nLogsFile <- RaftLogFile <$> logsFilePath nid
+      runRaftExampleT $ runRaftLogFileStoreT nLogsFile $ runRaftNode'
+        nSocketEnv
+        nPersistFile
+    PostgreSQL connInfo -> do
+      runRaftExampleT $ runRaftPostgresT connInfo $ runRaftNode' nSocketEnv
+                                                                 nPersistFile
+ where
+  runRaftNode'
+    :: ( MonadIO m
+       , MonadRaft StoreCmd m
+       , MonadFail m
+       , MonadMask m
+       , MonadRaft StoreCmd m
+       , RaftStateMachine m Store StoreCmd
+       , RaftInitLog m StoreCmd
+       , RaftReadLog m StoreCmd
+       , RaftWriteLog m StoreCmd
+       , RaftDeleteLog m StoreCmd
+       , Exception (RaftInitLogError m)
+       , Exception (RaftReadLogError m)
+       , Exception (RaftWriteLogError m)
+       , Exception (RaftDeleteLogError m)
+       , Typeable m
+       )
+    => NodeSocketEnv Store StoreCmd
+    -> RaftPersistFile
+    -> m ()
+  runRaftNode' nSocketEnv nPersistFile =
+    runRaftSocketT nSocketEnv $ runRaftPersistFileStoreT nPersistFile $ do
+      let allNodeIds = Set.fromList (nid : nids)
+      let nodeConfig = RaftNodeConfig
+            { raftConfigNodeId           = toS nid
+            , raftConfigNodeIds          = allNodeIds
+                        -- These are recommended timeouts from the original
+                        -- raft paper and the ARC report.
+            , raftConfigElectionTimeout  = (150000, 300000)
+            , raftConfigHeartbeatTimeout = 50000
+            , raftConfigStorageState     = storageState
+            }
+      runRaftNode nodeConfig
+                  defaultOptionalRaftNodeConfig
+                  (LogCtx LogStdout Debug)
+                  (mempty :: Store)
 
 cleanStorage :: FilePath -> LogStorage -> IO ()
 cleanStorage nodeDir ls = do
   case ls of
-    PostgreSQL connInfo -> do
-      Control.Monad.Catch.bracket (connect initConnInfo) close $ \conn ->
-        void $ deleteDB (connectDatabase connInfo) conn
+    PostgreSQL connInfo ->
+      Control.Monad.Catch.bracket (connect initConnInfo) close
+        $ \conn -> void $ deleteDB (connectDatabase connInfo) conn
     _ -> pure ()
   Directory.removePathForcibly nodeDir
   Directory.createDirectoryIfMissing False nodeDir
@@ -112,26 +118,29 @@ cleanStorage nodeDir ls = do
 persistentFilePath :: NodeId -> IO FilePath
 persistentFilePath nid = do
   tmpDir <- Directory.getTemporaryDirectory
-  pure $ tmpDir </> toS nid </> "persistent"
+  pure $ tmpDir </> (conv <$> toS nid) </> "persistent"
 
 logsFilePath :: NodeId -> IO FilePath
 logsFilePath nid = do
   tmpDir <- Directory.getTemporaryDirectory
-  pure (tmpDir </> toS nid </> "logs")
+  pure (tmpDir </> (conv <$> toS nid) </> "logs")
 
 initSocketEnv :: NodeId -> IO (NodeSocketEnv sm v)
 initSocketEnv nid = do
-  msgQueue <- atomically newTChan
+  msgQueue       <- atomically newTChan
   clientReqQueue <- atomically newTChan
   clientReqResps <- atomically $ newTVar Map.empty
-  pure NodeSocketEnv
-    { nsMsgQueue = msgQueue
-    , nsClientReqQueue = clientReqQueue
-    , nsClientReqResps = clientReqResps
-    }
+  pure NodeSocketEnv { nsMsgQueue       = msgQueue
+                     , nsClientReqQueue = clientReqQueue
+                     , nsClientReqResps = clientReqResps
+                     }
 
 mkExampleDir :: NodeId -> IO FilePath
 mkExampleDir nid = do
   tmpDir <- Directory.getTemporaryDirectory
-  let nodeDir = tmpDir </> toS nid
+  let nodeDir = tmpDir </> (conv <$> toS nid)
   pure nodeDir
+
+conv = \case
+  ':' -> '-'
+  x   -> x

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.7
+resolver: lts-14.4
 
 packages:
 - .
@@ -12,7 +12,7 @@ extra-deps:
 - concurrency-1.6.2.0
 - dejafu-1.12.0.0
 - tasty-dejafu-1.2.1.0
-- monad-metrics-0.2.1.2
+- monad-metrics-0.2.1.4
 - ekg-0.4.0.15
 - ekg-json-0.1.0.6
 


### PR DESCRIPTION
Primary purpose: Get the package compiling on Windows, and be able to
run `raft-example`

Other changes:
Hlint and uncontrolled formatting by vscode.

1. remove unused Language extensions.
2. remove implied Language extensions: Extension TypeSynonymInstances is implied by FlexibleInstances.
3. uncontrolled formatting by hie plugin for vscode.
4. update README to be compatible with the latest code (for
raft-example)

address issues: https://github.com/adjoint-io/raft/issues/140 and https://github.com/adjoint-io/raft/issues/139